### PR TITLE
Performance Optimizations

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -100,5 +100,5 @@ func (v *viewCommand) list(cmd *cobra.Command, args []string) error {
 		return todotxt.DefaultJsonEncoder.Encode(cmd.OutOrStdout(), list, getTasks(list))
 	}
 
-	return view.NewList(repo, projector, v.projection, getTasks, v.interactive).Run()
+	return view.NewList(repo, projector, v.projection, getTasks, v.interactive).Run(list)
 }

--- a/hook/clear.go
+++ b/hook/clear.go
@@ -11,7 +11,7 @@ type ClearOnDone struct {
 
 func (c ClearOnDone) OnMod(list *todotxt.List, event todotxt.ModEvent) error {
 	if event.IsCompleteEvent() {
-		return event.Current.EditDescription(event.Current.CleanDescription(qprojection.ExpandCleanExpression(list, c.Clear)))
+		return event.Current.EditDescription(event.Current.CleanDescription(qprojection.ExpandCleanExpression(event.Current, c.Clear)))
 	}
 	return nil
 }

--- a/qprojection/columns.go
+++ b/qprojection/columns.go
@@ -188,7 +188,7 @@ var descriptionColumn = columnDef{
 			}
 		}
 		return func(p Projector, l *todotxt.List, item *todotxt.Item) (string, lipgloss.Color) {
-			return runewidth.Truncate(item.CleanDescription(p.expandClean(l)), width, "..."), p.defaultColor
+			return runewidth.Truncate(item.CleanDescription(p.expandClean(item)), width, "..."), p.defaultColor
 		}
 	},
 }

--- a/qprojection/projection.go
+++ b/qprojection/projection.go
@@ -21,15 +21,6 @@ type Projector struct {
 	LineColors    ColorFunc
 	colorOverride *lipgloss.Color
 	defaultColor  lipgloss.Color
-	cache         *cacheStorage
-}
-
-type cacheStorage struct {
-	expandedClean *struct {
-		projects []todotxt.Project
-		contexts []todotxt.Context
-		tags     []string
-	}
 }
 
 func (p Projector) Verify(projection []string, list *todotxt.List) error {
@@ -53,8 +44,6 @@ func (p Projector) MustProject(projection []string, list *todotxt.List, selectio
 }
 
 func (p Projector) Project(projection []string, list *todotxt.List, selection []*todotxt.Item) ([]string, [][]string, [][]lipgloss.Style, error) {
-	p.cache = &cacheStorage{}
-	defer func() { p.cache = nil }()
 	headers, extractors, err := p.compile(projection, list)
 	if err != nil {
 		return nil, nil, nil, err
@@ -126,20 +115,7 @@ func (p Projector) expandAliasColumns(projection []string, list *todotxt.List) [
 }
 
 func (p Projector) expandClean(list *todotxt.List) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {
-	if p.cache.expandedClean != nil {
-		return p.cache.expandedClean.projects, p.cache.expandedClean.contexts, p.cache.expandedClean.tags
-	}
-	projects, contexts, tags := ExpandCleanExpression(list, p.Clean)
-	p.cache.expandedClean = &struct {
-		projects []todotxt.Project
-		contexts []todotxt.Context
-		tags     []string
-	}{
-		projects: projects,
-		contexts: contexts,
-		tags:     tags,
-	}
-	return projects, contexts, tags
+	return ExpandCleanExpression(list, p.Clean)
 }
 
 func ExpandCleanExpression(list *todotxt.List, clean []string) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {

--- a/qprojection/projection.go
+++ b/qprojection/projection.go
@@ -21,6 +21,15 @@ type Projector struct {
 	LineColors    ColorFunc
 	colorOverride *lipgloss.Color
 	defaultColor  lipgloss.Color
+	cache         *cacheStorage
+}
+
+type cacheStorage struct {
+	expandedClean *struct {
+		projects []todotxt.Project
+		contexts []todotxt.Context
+		tags     []string
+	}
 }
 
 func (p Projector) Verify(projection []string, list *todotxt.List) error {
@@ -44,6 +53,8 @@ func (p Projector) MustProject(projection []string, list *todotxt.List, selectio
 }
 
 func (p Projector) Project(projection []string, list *todotxt.List, selection []*todotxt.Item) ([]string, [][]string, [][]lipgloss.Style, error) {
+	p.cache = &cacheStorage{}
+	defer func() { p.cache = nil }()
 	headers, extractors, err := p.compile(projection, list)
 	if err != nil {
 		return nil, nil, nil, err
@@ -115,7 +126,20 @@ func (p Projector) expandAliasColumns(projection []string, list *todotxt.List) [
 }
 
 func (p Projector) expandClean(list *todotxt.List) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {
-	return ExpandCleanExpression(list, p.Clean)
+	if p.cache.expandedClean != nil {
+		return p.cache.expandedClean.projects, p.cache.expandedClean.contexts, p.cache.expandedClean.tags
+	}
+	projects, contexts, tags := ExpandCleanExpression(list, p.Clean)
+	p.cache.expandedClean = &struct {
+		projects []todotxt.Project
+		contexts []todotxt.Context
+		tags     []string
+	}{
+		projects: projects,
+		contexts: contexts,
+		tags:     tags,
+	}
+	return projects, contexts, tags
 }
 
 func ExpandCleanExpression(list *todotxt.List, clean []string) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {

--- a/qprojection/projection.go
+++ b/qprojection/projection.go
@@ -114,20 +114,20 @@ func (p Projector) expandAliasColumns(projection []string, list *todotxt.List) [
 	return realProjection
 }
 
-func (p Projector) expandClean(list *todotxt.List) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {
-	return ExpandCleanExpression(list, p.Clean)
+func (p Projector) expandClean(item *todotxt.Item) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {
+	return ExpandCleanExpression(item, p.Clean)
 }
 
-func ExpandCleanExpression(list *todotxt.List, clean []string) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {
+func ExpandCleanExpression(item *todotxt.Item, clean []string) (proj []todotxt.Project, ctx []todotxt.Context, tags []string) {
 	for _, c := range clean {
 		c := strings.TrimSpace(c)
 		switch {
 		case c == "+ALL":
-			proj = append(proj, list.AllProjects()...)
+			proj = append(proj, item.Projects()...)
 		case c == "@ALL":
-			ctx = append(ctx, list.AllContexts()...)
+			ctx = append(ctx, item.Contexts()...)
 		case c == "ALL":
-			tags = append(tags, list.AllTags()...)
+			tags = append(tags, item.Tags().Keys()...)
 		case strings.HasPrefix(c, "@"):
 			ctx = append(ctx, todotxt.Context(c[1:]))
 		case strings.HasPrefix(c, "+"):

--- a/view/list.go
+++ b/view/list.go
@@ -55,12 +55,8 @@ func NewList(repo *todotxt.Repo, proj qprojection.Projector, projection []string
 	return l
 }
 
-func (l List) Run() error {
-	firstList, err := l.repo.Read()
-	if err != nil {
-		return err
-	}
-	model, _ := l.Update(RefreshListMsg{List: firstList})
+func (l List) Run(initial *todotxt.List) error {
+	model, _ := l.Update(RefreshListMsg{List: initial})
 	l = model.(List)
 	switch l.interactive {
 	case true:


### PR DESCRIPTION
Adds two performance optimization:
1. Don't iterate the whole list n times to figure out what to trim from the description for display.
2. Don't load the list from disk twice when using list command.

- Add Option to limit the amount of tasks in list view
- Add fallback-chain with offsets for urgency score tags
- Replace Delete with slicing to avoid overwrites
- Add Cache for better performance
- Load list only once
- Revert "Add Cache for better performance"
- Make CleanExpression expansion based on item
