### PR TITLE
Add command to integrate with timewarrior

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -40,8 +40,7 @@ func (a *archiveCommand) command() *cobra.Command {
 		RunE:     a.archive,
 		PostRunE: cmdutil.Steps(cmdutil.SaveDoneList, cmdutil.SaveList),
 	}
-	archiveCommand.Flags().BoolVarP(&a.all, "all", "a", false, "TODO")
-	cmdutil.RegisterSelectionFlags(archiveCommand, &a.qql, &a.rng, &a.str)
+	cmdutil.RegisterSelectionFlags(archiveCommand, &a.qql, &a.rng, &a.str, &a.all)
 	return archiveCommand
 }
 

--- a/cmd/cmdutil/selection.go
+++ b/cmd/cmdutil/selection.go
@@ -7,10 +7,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func RegisterSelectionFlags(cmd *cobra.Command, qql *[]string, rng *[]string, str *[]string) {
+func RegisterSelectionFlags(cmd *cobra.Command, qql *[]string, rng *[]string, str *[]string, all *bool) {
 	cmd.Flags().StringArrayVarP(qql, "qql", "q", nil, "QQL Query")
 	cmd.Flags().StringArrayVarP(rng, "range", "r", nil, "Range Query")
 	cmd.Flags().StringArrayVarP(str, "word", "w", nil, "Case-Insensitive String Search")
+	if all != nil {
+		cmd.Flags().BoolVarP(all, "all", "a", false, "Don't ask for confirmation when multiple results match")
+	}
 }
 
 func ParseTaskSelection(defaultQuery string, guess, qqlSearch, rngSearch, stringSearch []string) (qselect.Func, error) {

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -40,8 +40,7 @@ func (c *completeCommand) command() *cobra.Command {
 		RunE:     c.complete,
 		PostRunE: cmdutil.Steps(cmdutil.SaveList),
 	}
-	completeCmd.Flags().BoolVarP(&c.all, "all", "a", false, "TODO")
-	cmdutil.RegisterSelectionFlags(completeCmd, &c.qql, &c.rng, &c.str)
+	cmdutil.RegisterSelectionFlags(completeCmd, &c.qql, &c.rng, &c.str, &c.all)
 	return completeCmd
 }
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -42,7 +42,7 @@ func (e *editCommand) command() *cobra.Command {
 		RunE:     e.edit,
 		PostRunE: cmdutil.Steps(cmdutil.SaveList),
 	}
-	cmdutil.RegisterSelectionFlags(editCommand, &e.qql, &e.rng, &e.str)
+	cmdutil.RegisterSelectionFlags(editCommand, &e.qql, &e.rng, &e.str, nil)
 	editCommand.Flags().StringSliceVarP(&e.sortOrder, "sort", "s", e.viewDef.Sort, "TODO")
 	return editCommand
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -60,6 +60,7 @@ func (v *viewCommand) command(name string) *cobra.Command {
 	listCmd.AddCommand(newArchiveCommand(v.def).command())
 	listCmd.AddCommand(newSetCommand(v.def).command())
 	listCmd.AddCommand(newUnsetCommand(v.def).command())
+	listCmd.AddCommand(newTrackCommand(v.def).command())
 
 	return listCmd
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,7 +50,7 @@ func (v *viewCommand) command(name string) *cobra.Command {
 	listCmd.Flags().IntVarP(&v.limit, "limit", "l", v.def.Limit, "Show only the first l items. Set to -1 to show all items")
 	listCmd.Flags().BoolVar(&v.json, "json", false, "Output the result in json format. This ignores -p")
 	listCmd.Flags().BoolVarP(&v.interactive, "interactive", "i", v.def.Interactive, "set to false to make the list non-interactive")
-	cmdutil.RegisterSelectionFlags(listCmd, &v.qqlSearch, &v.rngSearch, &v.stringSearch)
+	cmdutil.RegisterSelectionFlags(listCmd, &v.qqlSearch, &v.rngSearch, &v.stringSearch, nil)
 
 	listCmd.AddCommand(newAddCommand(v.def).command())
 	listCmd.AddCommand(newCompleteCommand(v.def).command())

--- a/cmd/prioritize.go
+++ b/cmd/prioritize.go
@@ -39,8 +39,7 @@ func (p *prioritizeCommand) command() *cobra.Command {
 		RunE:     p.prioritize,
 		PostRunE: cmdutil.Steps(cmdutil.SaveList),
 	}
-	prioritizeCommand.Flags().BoolVarP(&p.all, "all", "a", false, "TODO")
-	cmdutil.RegisterSelectionFlags(prioritizeCommand, &p.qql, &p.rng, &p.str)
+	cmdutil.RegisterSelectionFlags(prioritizeCommand, &p.qql, &p.rng, &p.str, &p.all)
 	return prioritizeCommand
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -35,8 +35,7 @@ func (r *removeCommand) command() *cobra.Command {
 		RunE:     r.remove,
 		PostRunE: cmdutil.Steps(cmdutil.SaveList),
 	}
-	removeCommand.Flags().BoolVarP(&r.all, "all", "a", false, "TODO")
-	cmdutil.RegisterSelectionFlags(removeCommand, &r.qql, &r.rng, &r.str)
+	cmdutil.RegisterSelectionFlags(removeCommand, &r.qql, &r.rng, &r.str, &r.all)
 	return removeCommand
 }
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -44,8 +44,7 @@ func (s *setCommand) command() *cobra.Command {
 		RunE:     s.set,
 		PostRunE: cmdutil.Steps(cmdutil.SaveList),
 	}
-	setCommand.Flags().BoolVarP(&s.all, "all", "a", false, "TODO")
-	cmdutil.RegisterSelectionFlags(setCommand, &s.qql, &s.rng, &s.str)
+	cmdutil.RegisterSelectionFlags(setCommand, &s.qql, &s.rng, &s.str, &s.all)
 	return setCommand
 }
 

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Fabian-G/quest/cmd/cmdutil"
+	"github.com/Fabian-G/quest/di"
+	"github.com/Fabian-G/quest/hook"
+	"github.com/Fabian-G/quest/todotxt"
+	"github.com/Fabian-G/quest/view"
+	"github.com/erikgeiser/promptkit/selection"
+	"github.com/spf13/cobra"
+)
+
+type trackCommand struct {
+	viewDef di.ViewDef
+	qql     []string
+	rng     []string
+	str     []string
+}
+
+func newTrackCommand(def di.ViewDef) *trackCommand {
+	cmd := trackCommand{
+		viewDef: def,
+	}
+
+	return &cmd
+}
+
+func (t *trackCommand) command() *cobra.Command {
+	var trackCommand = &cobra.Command{
+		Use:   "track [selectors...]",
+		Short: "Starts tracking the selected task with timewarrior",
+		Long: `
+track can be used to track the time spent on a task. 
+It does so by recording the start time in a special tag called quest-tr (in minutes since epoch).
+Since this alone ist not very useful it is recommended to install timewarrior.
+If timewarrior is installed the quest-tr tag will trigger a hook which propagates projects, contexts and description
+of the tracked task to timewarrior.
+Changes that are made to a task during an active tracking are automatically reflected in timewarrior.
+To stop tracking a task you can either remove the quest-tr tag from the active task or simply run "timew stop".
+`,
+		Example:  "quest track 3",
+		GroupID:  "view-cmd",
+		PreRunE:  cmdutil.Steps(cmdutil.LoadList),
+		RunE:     t.track,
+		PostRunE: cmdutil.Steps(cmdutil.SaveList),
+	}
+	cmdutil.RegisterSelectionFlags(trackCommand, &t.qql, &t.rng, &t.str, nil)
+	return trackCommand
+}
+
+func (t *trackCommand) track(cmd *cobra.Command, args []string) error {
+	list := cmd.Context().Value(cmdutil.ListKey).(*todotxt.List)
+
+	selector, err := cmdutil.ParseTaskSelection(t.viewDef.Query, args, t.qql, t.rng, t.str)
+	if err != nil {
+		return err
+	}
+
+	selectedTasks := selector.Filter(list)
+	if len(selectedTasks) == 0 {
+		fmt.Println("no matches")
+		return nil
+	}
+	selectedTask := selectedTasks[0]
+	if len(selectedTasks) > 1 {
+		t, err := selection.New("Select task to start tracking:", selectedTasks).RunPrompt()
+		if err != nil {
+			return fmt.Errorf("error during task selection: %w", err)
+		}
+		selectedTask = t
+	}
+
+	// We just set the tracking tag here. The tracking hook will do the actual work
+	if err := selectedTask.SetTag(hook.TrackingTag, strconv.FormatInt(time.Now().Unix()/60, 10)); err != nil {
+		return err
+	}
+	view.NewSuccessMessage("Started tracking", list, []*todotxt.Item{selectedTask}).Run()
+	return nil
+}

--- a/cmd/unset.go
+++ b/cmd/unset.go
@@ -42,8 +42,7 @@ func (u *unsetCommand) command() *cobra.Command {
 		RunE:     u.unset,
 		PostRunE: cmdutil.Steps(cmdutil.SaveList),
 	}
-	unsetCommand.Flags().BoolVarP(&u.all, "all", "a", false, "TODO")
-	cmdutil.RegisterSelectionFlags(unsetCommand, &u.qql, &u.rng, &u.str)
+	cmdutil.RegisterSelectionFlags(unsetCommand, &u.qql, &u.rng, &u.str, &u.all)
 	return unsetCommand
 }
 

--- a/di/config_provider.go
+++ b/di/config_provider.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/Fabian-G/quest/hook"
 	"github.com/Fabian-G/quest/qprojection"
 	"github.com/Fabian-G/quest/qselect"
 	"github.com/Fabian-G/quest/todotxt"
@@ -180,6 +181,10 @@ func buildConfig(file string) (Config, error) {
 	config.DoneFile = os.ExpandEnv(config.DoneFile)
 	config.Tags[InternalEditTag] = TagDef{
 		Type:     "int",
+		Humanize: false,
+	}
+	config.Tags[hook.TrackingTag] = TagDef{
+		Type:     "string",
 		Humanize: false,
 	}
 

--- a/hook/track.go
+++ b/hook/track.go
@@ -53,6 +53,8 @@ func (t Tracking) OnMod(list *todotxt.List, event todotxt.ModEvent) error {
 		}
 		if active {
 			return t.tracker.SetTags(trackingTags(event.Current))
+		} else if event.Previous.Tags()[TrackingTag][0] != event.Current.Tags()[TrackingTag][0] {
+			return t.tracker.Start(trackingTags(event.Current))
 		}
 	}
 	return nil
@@ -118,7 +120,7 @@ func (Tracking) OnValidate(list *todotxt.List, event todotxt.ValidationEvent) er
 			trTags++
 		}
 		if trTags > 1 {
-			return fmt.Errorf("Found multiple tracking tags %s.\nThis should never happen unless you edit them manually (which you should not).", TrackingTag)
+			return fmt.Errorf("Found multiple tracking tags %s.\nThis should never happen unless you edit them manually.", TrackingTag)
 		}
 	}
 	return nil

--- a/hook/track.go
+++ b/hook/track.go
@@ -29,8 +29,8 @@ type Tracking struct {
 }
 
 func (t Tracking) OnMod(list *todotxt.List, event todotxt.ModEvent) error {
-	prevTracked := event.Previous != nil && isTrackedTask(event.Previous)
-	curTracked := event.Current != nil && isTrackedTask(event.Current)
+	prevTracked := event.Previous != nil && !event.Previous.Done() && isTrackedTask(event.Previous)
+	curTracked := event.Current != nil && !event.Current.Done() && isTrackedTask(event.Current)
 	switch {
 	case !prevTracked && !curTracked:
 		// Nothing interesting in this case

--- a/hook/track.go
+++ b/hook/track.go
@@ -114,14 +114,5 @@ func trackingTags(item *todotxt.Item) []string {
 }
 
 func (Tracking) OnValidate(list *todotxt.List, event todotxt.ValidationEvent) error {
-	var trTags int
-	for _, item := range list.Tasks() {
-		if _, ok := item.Tags()[TrackingTag]; ok {
-			trTags++
-		}
-		if trTags > 1 {
-			return fmt.Errorf("Found multiple tracking tags %s.\nThis should never happen unless you edit them manually.", TrackingTag)
-		}
-	}
 	return nil
 }

--- a/hook/track.go
+++ b/hook/track.go
@@ -1,0 +1,125 @@
+package hook
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Fabian-G/quest/todotxt"
+)
+
+var TrackingTag = "quest-tr"
+
+var ErrNoActiveTracking = errors.New("No active tracking")
+
+type Tracker interface {
+	Start(tags []string) error
+	Stop() error
+	ActiveTags() ([]string, error)
+	SetTags(tags []string) error
+}
+
+func NewTracking(tracker Tracker) *Tracking {
+	return &Tracking{
+		tracker: tracker,
+	}
+}
+
+type Tracking struct {
+	tracker Tracker
+}
+
+func (t Tracking) OnMod(list *todotxt.List, event todotxt.ModEvent) error {
+	prevTracked := event.Previous != nil && isTrackedTask(event.Previous)
+	curTracked := event.Current != nil && isTrackedTask(event.Current)
+	switch {
+	case !prevTracked && !curTracked:
+		// Nothing interesting in this case
+		return nil
+	case !prevTracked && curTracked:
+		clearTrackingTag(list, event.Current)
+		return t.tracker.Start(trackingTags(event.Current))
+	case prevTracked && !curTracked:
+		active, err := t.stillActive(event.Previous)
+		if err != nil {
+			return err
+		}
+		if active {
+			return t.tracker.Stop()
+		}
+	case prevTracked && curTracked:
+		active, err := t.stillActive(event.Previous)
+		if err != nil {
+			return err
+		}
+		if active {
+			return t.tracker.SetTags(trackingTags(event.Current))
+		}
+	}
+	return nil
+}
+
+func (t Tracking) stillActive(item *todotxt.Item) (bool, error) {
+	tTags := trackingTags(item)
+	activeTags, err := t.tracker.ActiveTags()
+	if errors.Is(err, ErrNoActiveTracking) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("Could not obtain active tracking tags: %w", err)
+	}
+	if len(tTags) != len(activeTags) {
+		return false, nil
+	}
+	for i := range tTags {
+		if tTags[i] != activeTags[i] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func isTrackedTask(item *todotxt.Item) bool {
+	_, ok := item.Tags()[TrackingTag]
+	return ok
+}
+
+func clearTrackingTag(list *todotxt.List, item *todotxt.Item) {
+	for _, t := range list.Tasks() {
+		if t == item {
+			continue
+		}
+		// This can not error, because hooks are disabled at this point
+		if err := t.SetTag(TrackingTag, ""); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func trackingTags(item *todotxt.Item) []string {
+	projects := item.Projects()
+	contexts := item.Contexts()
+	tags := item.Tags()
+	description := item.CleanDescription(projects, contexts, tags.Keys())
+	trackingTags := make([]string, 0, len(projects)+len(contexts)+1)
+	for _, p := range projects {
+		trackingTags = append(trackingTags, p.String())
+	}
+	for _, c := range contexts {
+		trackingTags = append(trackingTags, c.String())
+	}
+	trackingTags = append(trackingTags, description)
+	return trackingTags
+}
+
+func (Tracking) OnValidate(list *todotxt.List, event todotxt.ValidationEvent) error {
+	var trTags int
+	for _, item := range list.Tasks() {
+		if _, ok := item.Tags()[TrackingTag]; ok {
+			trTags++
+		}
+		if trTags > 1 {
+			return fmt.Errorf("Found multiple tracking tags %s.\nThis should never happen unless you edit them manually (which you should not).", TrackingTag)
+		}
+	}
+	return nil
+}

--- a/hook/track_test.go
+++ b/hook/track_test.go
@@ -159,3 +159,32 @@ func Test_StartOverridesActiveTracking(t *testing.T) {
 	assert.Equal(t, 2, len(mock.startCalls))
 	assert.Equal(t, []string{"Item 1"}, mock.startCalls[1])
 }
+
+func Test_RestartingTrackingCanBeDoneBySettingADifferentValue(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1 " + hook.TrackingTag + ":latest")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "another-value")
+	assert.NoError(t, err)
+
+	assert.True(t, mock.active)
+	assert.Equal(t, 1, len(mock.startCalls))
+	assert.Equal(t, []string{"Item 1"}, mock.startCalls[0])
+}
+
+func Test_NotChangingTheTrackingTagDoesNotRestartTrackingOnChange(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1 " + hook.TrackingTag + ":latest")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag("some-tag", "some-value")
+	assert.NoError(t, err)
+
+	assert.False(t, mock.active)
+	assert.Equal(t, 0, len(mock.startCalls))
+}

--- a/hook/track_test.go
+++ b/hook/track_test.go
@@ -188,3 +188,37 @@ func Test_NotChangingTheTrackingTagDoesNotRestartTrackingOnChange(t *testing.T) 
 	assert.False(t, mock.active)
 	assert.Equal(t, 0, len(mock.startCalls))
 }
+
+func Test_CompletingATaskStopsTracking(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+	err = list.Tasks()[0].Complete()
+	assert.NoError(t, err)
+
+	assert.False(t, mock.active)
+	assert.Equal(t, 1, len(mock.startCalls))
+	assert.Equal(t, 1, mock.stopCalls)
+}
+
+func Test_RemovingATaskStopsTracking(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+	err = list.Remove(1)
+	assert.NoError(t, err)
+
+	assert.False(t, mock.active)
+	assert.Equal(t, 1, len(mock.startCalls))
+	assert.Equal(t, 1, mock.stopCalls)
+}

--- a/hook/track_test.go
+++ b/hook/track_test.go
@@ -1,7 +1,6 @@
 package hook_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/Fabian-G/quest/hook"
@@ -47,20 +46,6 @@ func (t *trackerMock) Stop() error {
 	t.active = false
 	t.currentTags = nil
 	return nil
-}
-
-func Test_TrackingErrorsOnMultipleTrackingTags(t *testing.T) {
-	list := todotxt.ListOf(
-		todotxt.MustBuildItem(todotxt.WithDescription("Item 1 "+hook.TrackingTag+":latest")),
-		todotxt.MustBuildItem(todotxt.WithDescription("Item 2 ")),
-		todotxt.MustBuildItem(todotxt.WithDescription("Item 3 "+hook.TrackingTag+":latest")),
-	)
-	list.AddHook(hook.NewTracking(&trackerMock{}))
-
-	// Trigger validation by serializing
-	err := todotxt.DefaultEncoder.Encode(&bytes.Buffer{}, list.Tasks())
-
-	assert.Error(t, err)
 }
 
 func Test_TrackingClearsTrackingTagOnOthersAfterStarting(t *testing.T) {

--- a/hook/track_test.go
+++ b/hook/track_test.go
@@ -1,0 +1,161 @@
+package hook_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Fabian-G/quest/hook"
+	"github.com/Fabian-G/quest/todotxt"
+	"github.com/stretchr/testify/assert"
+)
+
+type trackerMock struct {
+	activeTagsCalls int
+	setTagsCalls    [][]string
+	startCalls      [][]string
+	stopCalls       int
+	active          bool
+	currentTags     []string
+}
+
+func (t *trackerMock) ActiveTags() ([]string, error) {
+	t.activeTagsCalls++
+	if !t.active {
+		return nil, hook.ErrNoActiveTracking
+	}
+	return t.currentTags, nil
+}
+
+func (t *trackerMock) SetTags(tags []string) error {
+	t.setTagsCalls = append(t.setTagsCalls, tags)
+	if !t.active {
+		return hook.ErrNoActiveTracking
+	}
+	t.currentTags = tags
+	return nil
+}
+
+func (t *trackerMock) Start(tags []string) error {
+	t.startCalls = append(t.startCalls, tags)
+	t.active = true
+	t.currentTags = tags
+	return nil
+}
+
+func (t *trackerMock) Stop() error {
+	t.stopCalls++
+	t.active = false
+	t.currentTags = nil
+	return nil
+}
+
+func Test_TrackingErrorsOnMultipleTrackingTags(t *testing.T) {
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1 "+hook.TrackingTag+":latest")),
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 2 ")),
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 3 "+hook.TrackingTag+":latest")),
+	)
+	list.AddHook(hook.NewTracking(&trackerMock{}))
+
+	// Trigger validation by serializing
+	err := todotxt.DefaultEncoder.Encode(&bytes.Buffer{}, list.Tasks())
+
+	assert.Error(t, err)
+}
+
+func Test_TrackingClearsTrackingTagOnOthersAfterStarting(t *testing.T) {
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1 "+hook.TrackingTag+":latest")),
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 2 ")),
+	)
+	list.AddHook(hook.NewTracking(&trackerMock{}))
+
+	err := list.Tasks()[1].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+
+	_, ok := list.Tasks()[0].Tags()[hook.TrackingTag]
+	assert.False(t, ok)
+}
+
+func Test_TrackingCallsStartWhenAddingTheTrackingTag(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("@aContext Item 1 +aProject an:ignored-tag")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+
+	assert.True(t, mock.active)
+	assert.Equal(t, 1, len(mock.startCalls))
+	// Also test for the correct order of tags here
+	assert.Equal(t, []string{"+aProject", "@aContext", "Item 1"}, mock.startCalls[0])
+}
+
+func Test_RemovingTheTrackingTagStopsTheTracking(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("@aContext Item 1 +aProject an:ignored-tag")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+	err = list.Tasks()[0].SetTag(hook.TrackingTag, "")
+	assert.NoError(t, err)
+
+	assert.False(t, mock.active)
+	assert.Equal(t, 1, mock.stopCalls)
+}
+
+func Test_ChangesWillPropagateToTheTracker(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("@aContext Item 1 +aProject an:ignored-tag")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+	err = list.Tasks()[0].EditDescription(list.Tasks()[0].Description() + " @anotherContext")
+	assert.NoError(t, err)
+
+	assert.True(t, mock.active)
+	assert.Equal(t, 1, len(mock.startCalls))
+	assert.Equal(t, 1, len(mock.setTagsCalls))
+	assert.Equal(t, []string{"+aProject", "@aContext", "@anotherContext", "Item 1"}, mock.setTagsCalls[0])
+}
+
+func Test_OutOfBandChangesAreNotOverriden(t *testing.T) {
+	mock := &trackerMock{}
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("@aContext Item 1 +aProject an:ignored-tag")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+	mock.Start([]string{"Some", "Unrelated", "Tags"})
+	err = list.Tasks()[0].EditDescription(list.Tasks()[0].Description() + " @anotherContext")
+	assert.NoError(t, err)
+
+	assert.True(t, mock.active)
+	assert.Equal(t, []string{"Some", "Unrelated", "Tags"}, mock.currentTags)
+}
+
+func Test_StartOverridesActiveTracking(t *testing.T) {
+	mock := &trackerMock{}
+	mock.Start([]string{"Some", "oob", "tracking"})
+	list := todotxt.ListOf(
+		todotxt.MustBuildItem(todotxt.WithDescription("Item 1")),
+	)
+	list.AddHook(hook.NewTracking(mock))
+
+	err := list.Tasks()[0].SetTag(hook.TrackingTag, "latest")
+	assert.NoError(t, err)
+
+	assert.True(t, mock.active)
+	assert.Equal(t, 2, len(mock.startCalls))
+	assert.Equal(t, []string{"Item 1"}, mock.startCalls[1])
+}


### PR DESCRIPTION
Adds a command and a hook to track time with taskwarrior.

- Add Option to limit the amount of tasks in list view
- Add fallback-chain with offsets for urgency score tags
- Replace Delete with slicing to avoid overwrites
- Add tracking hook
- Move all flag to selection flags
- Add track command
- Auto clear tracking tag on completion
- Drop validation for tracking
