### PR TITLE
Error on malformed int tag

### DIFF
--- a/hook/tagexpansion.go
+++ b/hook/tagexpansion.go
@@ -136,11 +136,6 @@ func (t TagExpansion) findNext(day time.Weekday) time.Time {
 }
 
 func (t TagExpansion) expandInt(list *todotxt.List, i *todotxt.Item, tag string, value string) string {
-	if _, err := strconv.Atoi(value); err == nil {
-		// This is already a proper integer
-		return value
-	}
-
 	var base int
 	var remainingValue string
 	switch {
@@ -156,6 +151,10 @@ func (t TagExpansion) expandInt(list *todotxt.List, i *todotxt.Item, tag string,
 	case strings.HasPrefix(value, "pmin"):
 		base = t.projectMinValue(list, i.Projects(), tag)
 		remainingValue = strings.TrimPrefix(value, "pmin")
+	default:
+		// Assume that this is already a properly formatted integer.
+		// If it is not this error will be caught by validation.
+		return value
 	}
 	if len(strings.TrimSpace(remainingValue)) == 0 {
 		return strconv.Itoa(base)

--- a/hook/tagexpansion_test.go
+++ b/hook/tagexpansion_test.go
@@ -223,7 +223,7 @@ func Test_TagExpansionsError(t *testing.T) {
 			description: "hello unknown:tag abc",
 		},
 		"wrong expansion": {
-			description: "a wrong int someint:expansion",
+			description: "a wrong int someInt:expansion",
 		},
 	}
 


### PR DESCRIPTION
Previously malformed int tag were just expanded to 0.
Which is unexpcted behaviour.

- Add Option to limit the amount of tasks in list view
- Add fallback-chain with offsets for urgency score tags
- Replace Delete with slicing to avoid overwrites
- Don't expand strings to 0
